### PR TITLE
Add minimal Next.js web interface with Task Master API

### DIFF
--- a/.roo/mcp.json
+++ b/.roo/mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "taskmaster-ai": {
+      "command": "npx",
+      "args": ["-y", "--package=task-master-ai", "task-master-ai"],
+      "env": {
+        "ANTHROPIC_API_KEY": "YOUR_ANTHROPIC_API_KEY",
+        "PERPLEXITY_API_KEY": "YOUR_PERPLEXITY_API_KEY"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -306,6 +306,21 @@ DafnckMachine uses MCP servers for advanced agent and workflow integration (Curs
 - For more details, see the comments in the template files and the main README.
 
 ---
+## Web Interface
+
+The optional web UI lives in `web-ui/` and provides a simple dashboard for Task Master.
+
+### Installation
+
+```bash
+cd web-ui
+npm install
+npm run dev
+```
+
+### Usage
+
+Open `http://localhost:3000` in your browser. The interface lists current tasks, lets you view details, and includes a form to add or update tasks using the Task Master server defined in `.roo/mcp.json`.
 
 **Last Updated**: 2025-06-05  
 **Support**: See `01_Machine/04_Documentation/`  

--- a/web-ui/components/TaskList.jsx
+++ b/web-ui/components/TaskList.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+
+export default function TaskList() {
+  const [tasks, setTasks] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    fetch('/api/tasks')
+      .then(res => res.json())
+      .then(data => {
+        try {
+          const parsed = JSON.parse(data.output || '[]');
+          setTasks(parsed);
+        } catch {
+          setTasks([]);
+        }
+      });
+  }, []);
+
+  const viewTask = id => {
+    fetch(`/api/tasks?id=${id}`)
+      .then(res => res.json())
+      .then(data => {
+        try {
+          setSelected(JSON.parse(data.output));
+        } catch {
+          setSelected(null);
+        }
+      });
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    const command = `add_task \"${title}\" \"${description}\"`;
+    fetch('/api/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command })
+    }).then(() => {
+      setTitle('');
+      setDescription('');
+      // Refresh task list
+      fetch('/api/tasks')
+        .then(res => res.json())
+        .then(data => {
+          try {
+            setTasks(JSON.parse(data.output || '[]'));
+          } catch {
+            setTasks([]);
+          }
+        });
+    });
+  };
+
+  return (
+    <div>
+      <h1>Tasks</h1>
+      <ul>
+        {tasks.map(task => (
+          <li key={task.id} onClick={() => viewTask(task.id)} style={{cursor:'pointer'}}>
+            {task.title || task.name}
+          </li>
+        ))}
+      </ul>
+      {selected && (
+        <div>
+          <h2>Task {selected.id}</h2>
+          <p>{selected.title}</p>
+          <p>{selected.description}</p>
+        </div>
+      )}
+      <form onSubmit={handleSubmit} style={{marginTop:'1rem'}}>
+        <input
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder="Title"
+        />
+        <br />
+        <textarea
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          placeholder="Description"
+        />
+        <br />
+        <button type="submit">Add Task</button>
+      </form>
+    </div>
+  );
+}

--- a/web-ui/next.config.js
+++ b/web-ui/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "web-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/web-ui/pages/api/tasks.js
+++ b/web-ui/pages/api/tasks.js
@@ -1,0 +1,48 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { exec } from 'child_process';
+
+async function loadConfig() {
+  const mcpPath = path.join(process.cwd(), '..', '.roo', 'mcp.json');
+  const data = await fs.readFile(mcpPath, 'utf-8');
+  const config = JSON.parse(data);
+  return config.mcpServers?.['taskmaster-ai'];
+}
+
+function runCommand(cmd) {
+  return new Promise((resolve, reject) => {
+    exec(cmd, (error, stdout, stderr) => {
+      if (error) {
+        reject(stderr || error.message);
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}
+
+export default async function handler(req, res) {
+  try {
+    const server = await loadConfig();
+    if (!server) throw new Error('taskmaster-ai not configured');
+    const base = [server.command, ...server.args].join(' ');
+
+    let output;
+    if (req.method === 'GET') {
+      if (req.query.id) {
+        output = await runCommand(`${base} get_task ${req.query.id}`);
+      } else {
+        output = await runCommand(`${base} get_tasks`);
+      }
+    } else if (req.method === 'POST') {
+      const { command } = req.body;
+      output = await runCommand(`${base} ${command}`);
+    } else {
+      res.status(405).end();
+      return;
+    }
+    res.status(200).json({ output });
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
+}

--- a/web-ui/pages/index.js
+++ b/web-ui/pages/index.js
@@ -1,0 +1,5 @@
+import TaskList from '../components/TaskList';
+
+export default function Home() {
+  return <TaskList />;
+}


### PR DESCRIPTION
## Summary
- scaffold `web-ui` folder with a bare Next.js project
- provide API route that loads `.roo/mcp.json` and runs Task Master commands
- implement a simple `TaskList` component to list, show and add tasks
- add `.roo/mcp.json` with placeholder configuration
- document the new web UI in `README.md`

## Testing
- `node update_output_artifacts_checklist.js`
- `npm run --prefix web-ui build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843fe1de314832882856fb328167ef0